### PR TITLE
[WIP] make retriever page content just the content

### DIFF
--- a/dialog_lib/embeddings/retrievers.py
+++ b/dialog_lib/embeddings/retrievers.py
@@ -29,9 +29,10 @@ class DialogRetriever(BaseRetriever):
         )
         return [
             Document(
-                page_content=f"{content.question}\n\n{content.content}",
+                page_content=content.content,
                 metadata={
-                    "title": content.question,
+                    "question": content.question,
+                    "title": content.question, # compatibility
                     "category": content.category,
                     "subcategory": content.subcategory,
                     "dataset": content.dataset,


### PR DESCRIPTION
Addresses this [dialog issue](https://github.com/talkdai/dialog/issues/206). This retriever is only used in `lcel.py` for now, for instance:

https://github.com/talkdai/dialog/blob/14e19f619155a710de4c350c0a78adc1942ae9d6/src/dialog/llm/agents/lcel.py#L60-L61

Users that already uses this project as-is, leaving questions in the `question` field and answers in the `content` csv field would have to be informed that this change will demand them to either join question/answer before into the `content` field or chose another `format_docs` function (which will be coerced into a runnable), in this case by using a plugin.