### PR TITLE
Adds session injection function for better session management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python
 n
+.envrc

--- a/dialog_lib/agents/abstract.py
+++ b/dialog_lib/agents/abstract.py
@@ -12,6 +12,7 @@ from langchain_core.runnables import RunnablePassthrough, RunnableParallel, Runn
 from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain.chains.conversation.memory import ConversationBufferMemory
 
+from dialog_lib.db import get_session
 from dialog_lib.db.memory import CustomPostgresChatMessageHistory, get_memory_instance
 from dialog_lib.embeddings.retrievers import DialogRetriever
 
@@ -24,7 +25,7 @@ class AbstractLLM:
         parent_session_id=None,
         dataset=None,
         llm_api_key=None,
-        dbsession=None,
+        dbsession=get_session(),
     ):
         """
         :param config: Configuration dictionary

--- a/dialog_lib/db/__init__.py
+++ b/dialog_lib/db/__init__.py
@@ -4,3 +4,4 @@ from .memory import (
     add_user_message_to_message_history,
     get_messages,
 )
+from .session import get_session

--- a/dialog_lib/db/memory.py
+++ b/dialog_lib/db/memory.py
@@ -1,5 +1,5 @@
 import psycopg
-
+from .session import get_session
 from langchain_postgres import PostgresChatMessageHistory
 from langchain.schema.messages import BaseMessage, _message_to_dict
 
@@ -15,7 +15,7 @@ class CustomPostgresChatMessageHistory(PostgresChatMessageHistory):
         self,
         *args,
         parent_session_id=None,
-        dbsession=None,
+        dbsession=get_session(),
         chats_model=Chat,
         chat_messages_model=ChatMessages,
         ssl_mode=None,
@@ -67,7 +67,7 @@ class CustomPostgresChatMessageHistory(PostgresChatMessageHistory):
 def generate_memory_instance(
     session_id,
     parent_session_id=None,
-    dbsession=None,
+    dbsession=get_session(),
     database_url=None,
     chats_model=Chat,
     chat_messages_model=ChatMessages,
@@ -88,7 +88,7 @@ def generate_memory_instance(
 
 
 def add_user_message_to_message_history(
-    session_id, message, memory=None, dbsession=None, database_url=None
+    session_id, message, memory=None, dbsession=get_session(), database_url=None
 ):
     """
     Add a user message to the message history and returns the updated
@@ -103,7 +103,7 @@ def add_user_message_to_message_history(
     return memory
 
 
-def get_messages(session_id, dbsession=None, database_url=None):
+def get_messages(session_id, dbsession=get_session(), database_url=None):
     """
     Get all messages for a given session_id
     """

--- a/dialog_lib/db/memory.py
+++ b/dialog_lib/db/memory.py
@@ -15,7 +15,7 @@ class CustomPostgresChatMessageHistory(PostgresChatMessageHistory):
         self,
         *args,
         parent_session_id=None,
-        dbsession=get_session(),
+        dbsession=get_session,
         chats_model=Chat,
         chat_messages_model=ChatMessages,
         ssl_mode=None,
@@ -48,10 +48,10 @@ class CustomPostgresChatMessageHistory(PostgresChatMessageHistory):
 
     def add_tags(self, tags: str) -> None:
         """Add tags for a given session_id/uuid on chats table"""
-        self.dbsession.query(self.chats_model).where(
-            self.chats_model.session_id == self._session_id
-        ).update({getattr(self.chats_model, "tags"): tags})
-        self.dbsession.commit()
+        with self.dbsession() as session:
+            session.query(self.chats_model).where(
+                self.chats_model.session_id == self._session_id
+            ).update({getattr(self.chats_model, "tags"): tags})
 
     def add_message(self, message: BaseMessage) -> None:
         """Append the message to the record in PostgreSQL"""
@@ -61,13 +61,12 @@ class CustomPostgresChatMessageHistory(PostgresChatMessageHistory):
         if self.parent_session_id:
             message.parent = self.parent_session_id
         self.dbsession.add(message)
-        self.dbsession.commit()
 
 
 def generate_memory_instance(
     session_id,
     parent_session_id=None,
-    dbsession=get_session(),
+    dbsession=get_session,
     database_url=None,
     chats_model=Chat,
     chat_messages_model=ChatMessages,
@@ -88,29 +87,31 @@ def generate_memory_instance(
 
 
 def add_user_message_to_message_history(
-    session_id, message, memory=None, dbsession=get_session(), database_url=None
+    session_id, message, memory=None, dbsession=get_session, database_url=None
 ):
     """
     Add a user message to the message history and returns the updated
     memory instance
     """
-    if not memory:
-        memory = generate_memory_instance(
-            session_id, dbsession=dbsession, database_url=database_url
-        )
+    with dbsession() as session:
+        if not memory:
+            memory = generate_memory_instance(
+                session_id, dbsession=session, database_url=database_url
+            )
 
-    memory.add_user_message(message)
-    return memory
+        memory.add_user_message(message)
+        return memory
 
 
-def get_messages(session_id, dbsession=get_session(), database_url=None):
+def get_messages(session_id, dbsession=get_session, database_url=None):
     """
     Get all messages for a given session_id
     """
-    memory = generate_memory_instance(
-        session_id, dbsession=dbsession, database_url=database_url
-    )
-    return memory.messages
+    with dbsession() as session:
+        memory = generate_memory_instance(
+            session_id, dbsession=session, database_url=database_url
+        )
+        return memory.messages
 
 def get_memory_instance(session_id, sqlalchemy_session, database_url):
     return generate_memory_instance(

--- a/dialog_lib/db/session.py
+++ b/dialog_lib/db/session.py
@@ -1,0 +1,10 @@
+import os
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+def get_session():
+    engine = sa.create_engine(os.environ.get("DATABASE_URL"))
+    session = Session(engine)
+    yield session
+    session.close()

--- a/dialog_lib/db/session.py
+++ b/dialog_lib/db/session.py
@@ -10,13 +10,10 @@ Session = sessionmaker(bind=engine)
 
 @contextmanager
 def get_session():
-    session = Session()
-    try:
-        yield session
-        session.flush()
-        session.commit()
-    except Exception as e:
-        session.rollback()
-        raise e
-    finally:
-        session.close()
+    with Session() as session:
+        try:
+            yield session
+            session.commit()
+        except Exception as exc:
+            session.rollback()
+            raise exc

--- a/dialog_lib/db/utils.py
+++ b/dialog_lib/db/utils.py
@@ -3,14 +3,14 @@ from .session import get_session
 from .models import Chat
 
 
-def create_chat_session(identifier=None, dbsession=get_session(), model=Chat):
+def create_chat_session(identifier=None, dbsession=get_session, model=Chat):
     if identifier is None:
         identifier = uuid.uuid4().hex
 
-    chat = dbsession.query(model).filter_by(session_id=identifier).first()
-    if not chat:
-        chat = model(session_id=identifier)
-        dbsession.add(chat)
-        dbsession.commit()
+    with dbsession() as session:
+        chat = session.query(model).filter_by(session_id=identifier).first()
+        if not chat:
+            chat = model(session_id=identifier)
+            session.add(chat)
 
     return {"chat_id": chat.session_id}

--- a/dialog_lib/db/utils.py
+++ b/dialog_lib/db/utils.py
@@ -1,9 +1,9 @@
 import uuid
-
+from .session import get_session
 from .models import Chat
 
 
-def create_chat_session(identifier=None, dbsession=None, model=Chat):
+def create_chat_session(identifier=None, dbsession=get_session(), model=Chat):
     if identifier is None:
         identifier = uuid.uuid4().hex
 

--- a/dialog_lib/loaders/csv.py
+++ b/dialog_lib/loaders/csv.py
@@ -1,3 +1,4 @@
+from dialog_lib.db import get_session
 from dialog_lib.db.models import CompanyContent
 from dialog_lib.embeddings.generate import generate_embedding
 
@@ -6,9 +7,10 @@ from langchain_community.document_loaders.csv_loader import CSVLoader
 
 
 def load_csv(
-        file_path, dbsession, embeddings_model_instance=None,
+        file_path, dbsession=get_session(), embeddings_model_instance=None,
         embedding_llm_model=None, embedding_llm_api_key=None, company_id=None
     ):
+
     loader = CSVLoader(file_path=file_path)
     contents = loader.load()
 

--- a/dialog_lib/loaders/csv.py
+++ b/dialog_lib/loaders/csv.py
@@ -7,7 +7,7 @@ from langchain_community.document_loaders.csv_loader import CSVLoader
 
 
 def load_csv(
-        file_path, dbsession=get_session(), embeddings_model_instance=None,
+        file_path, dbsession=get_session, embeddings_model_instance=None,
         embedding_llm_model=None, embedding_llm_api_key=None, company_id=None
     ):
 
@@ -20,22 +20,22 @@ def load_csv(
         else:
             raise ValueError("Invalid embeddings model")
 
-    for csv_content in contents:
-        content = {}
+    with dbsession() as session:
+        for csv_content in contents:
+            content = {}
 
-        for line in csv_content.page_content.split("\n"):
-            values = line.split(": ")
-            content[values[0]] = values[1]
+            for line in csv_content.page_content.split("\n"):
+                values = line.split(": ")
+                content[values[0]] = values[1]
 
-        company_content = CompanyContent(
-            category="csv",
-            subcategory="csv-content",
-            question=content["question"],
-            content=content["content"],
-            dataset=company_id,
-            embedding=generate_embedding(csv_content.page_content, embeddings_model_instance)
-        )
-        dbsession.add(company_content)
+            company_content = CompanyContent(
+                category="csv",
+                subcategory="csv-content",
+                question=content["question"],
+                content=content["content"],
+                dataset=company_id,
+                embedding=generate_embedding(csv_content.page_content, embeddings_model_instance)
+            )
+            session.add(company_content)
 
-    dbsession.commit()
     return company_content

--- a/dialog_lib/loaders/web.py
+++ b/dialog_lib/loaders/web.py
@@ -1,10 +1,10 @@
 from dialog_lib.db.models import CompanyContent
 from dialog_lib.embeddings.generate import generate_embedding
-
+from dialog_lib.db import get_session
 from langchain_community.document_loaders import WebBaseLoader
 
 
-def load_webpage(url, dbsession, embeddings_model_instance, company_id=None):
+def load_webpage(url, embeddings_model_instance, dbsession=get_session(), company_id=None):
     loader = WebBaseLoader(url)
     contents = loader.load()
 

--- a/dialog_lib/loaders/web.py
+++ b/dialog_lib/loaders/web.py
@@ -4,21 +4,21 @@ from dialog_lib.db import get_session
 from langchain_community.document_loaders import WebBaseLoader
 
 
-def load_webpage(url, embeddings_model_instance, dbsession=get_session(), company_id=None):
+def load_webpage(url, embeddings_model_instance, dbsession=get_session, company_id=None):
     loader = WebBaseLoader(url)
     contents = loader.load()
 
-    for url_content in contents:
-        company_content = CompanyContent(
-            link=url,
-            category="web",
-            subcategory="website-content",
-            question=url_content.metadata["title"],
-            content=url_content.page_content,
-            dataset=company_id,
-            embedding=generate_embedding(url_content.page_content, embeddings_model_instance)
-        )
-        dbsession.add(company_content)
-        dbsession.flush()
+    with dbsession() as session:
+        for url_content in contents:
+            company_content = CompanyContent(
+                link=url,
+                category="web",
+                subcategory="website-content",
+                question=url_content.metadata["title"],
+                content=url_content.page_content,
+                dataset=company_id,
+                embedding=generate_embedding(url_content.page_content, embeddings_model_instance)
+            )
+            session.add(company_content)
 
     return company_content

--- a/dialog_lib/manage.py
+++ b/dialog_lib/manage.py
@@ -78,12 +78,13 @@ def anthropic(model, temperature, llm_api_key, prompt, debug):
 def load_csv(database_url, llm_api_key, file):
     engine = create_engine(database_url)
     dbsession = Session(engine.connect())
-    csv_loader(
-        file_path=file,
-        dbsession=dbsession,
-        embedding_llm_model="openai",
-        embedding_llm_api_key=llm_api_key
-    )
+    with Session(engine.connect()) as session:
+        csv_loader(
+            file_path=file,
+            dbsession=session,
+            embedding_llm_model="openai",
+            embedding_llm_api_key=llm_api_key
+        )
     click.echo("## Loaded the CSV file to the database")
 
 

--- a/dialog_lib/manage.py
+++ b/dialog_lib/manage.py
@@ -85,7 +85,6 @@ def load_csv(database_url, llm_api_key, file):
         embedding_llm_api_key=llm_api_key
     )
     click.echo("## Loaded the CSV file to the database")
-    dbsession.close()
 
 
 def main():

--- a/dialog_lib/manage.py
+++ b/dialog_lib/manage.py
@@ -76,7 +76,6 @@ def anthropic(model, temperature, llm_api_key, prompt, debug):
 @click.option("--llm-api-key", default=get_llm_key(), help="The LLM API key", required=True)
 @click.option("--file", help="The CSV file to load the data from", required=True)
 def load_csv(database_url, llm_api_key, file):
-    breakpoint()
     engine = create_engine(database_url)
     dbsession = Session(engine.connect())
     csv_loader(
@@ -86,6 +85,7 @@ def load_csv(database_url, llm_api_key, file):
         embedding_llm_api_key=llm_api_key
     )
     click.echo("## Loaded the CSV file to the database")
+    dbsession.close()
 
 
 def main():

--- a/dialog_lib/tests/agents/test_abstract_agents.py
+++ b/dialog_lib/tests/agents/test_abstract_agents.py
@@ -20,7 +20,6 @@ def test_abstract_agent_with_valid_config():
     assert agent.dataset is None
     assert agent.llm_api_key is None
     assert agent.parent_session_id is None
-    assert agent.dbsession is None
 
 def test_abstract_agent_get_prompt():
     config = {

--- a/dialog_lib/tests/conftest.py
+++ b/dialog_lib/tests/conftest.py
@@ -5,19 +5,18 @@ import sqlalchemy
 from aioresponses import aioresponses
 from sqlalchemy.orm import Session
 from dialog_lib.db.models import Base
+from dialog_lib.db import get_session
 
 
 @pytest.fixture
 def db_engine():
     return sqlalchemy.create_engine(os.environ.get('DATABASE_URL'))
 
+
 @pytest.fixture
-def db_session(db_engine):
-    Base.metadata.create_all(db_engine)
-    session = Session(db_engine)
-    yield session
-    session.rollback()
-    session.close()
+def db_session():
+    return get_session
+
 
 @pytest.fixture
 def mock_aioresponse():

--- a/dialog_lib/tests/loaders/test_web_loader.py
+++ b/dialog_lib/tests/loaders/test_web_loader.py
@@ -9,9 +9,10 @@ def test_load_web_content(mock_aioresponse, db_session, mocker):
     mocker.patch('dialog_lib.loaders.web.generate_embedding', return_value=[0] * 1536)
     mock_aioresponse.get('http://example.com', body='Hello, world!')
 
-    content = load_webpage('http://example.com', None, db_session, 1)
-    assert content.question == "Example Domain"
-    assert content.embedding == [0] * 1536
+    load_webpage('http://example.com', None, db_session, 1)
 
-    content = db_session.query(CompanyContent).all()
-    assert len(content) == 1
+    with db_session() as session:
+        content = session.query(CompanyContent).first()
+        assert content.question == "Example Domain"
+        assert content.embedding.tolist() == [0]*1536
+

--- a/dialog_lib/tests/loaders/test_web_loader.py
+++ b/dialog_lib/tests/loaders/test_web_loader.py
@@ -9,7 +9,7 @@ def test_load_web_content(mock_aioresponse, db_session, mocker):
     mocker.patch('dialog_lib.loaders.web.generate_embedding', return_value=[0] * 1536)
     mock_aioresponse.get('http://example.com', body='Hello, world!')
 
-    content = load_webpage('http://example.com', db_session, None, 1)
+    content = load_webpage('http://example.com', None, db_session, 1)
     assert content.question == "Example Domain"
     assert content.embedding == [0] * 1536
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dialog-lib"
-version = "0.0.2.0"
+version = "0.0.2.1"
 description = ""
 authors = ["Talkd.AI <foss@talkd.ai>"]
 license = "MIT"


### PR DESCRIPTION
In this PR, we are adding the capacity of having the database session management inside the dialog_lib's repo, so we can let the user use it as a standalone library without any modification as a suggestion from @lgabs.

If the user doesn't want to use the session we provide in the library, the user can replace It using their own SQLAlchemy session in the `dbsession` argument on the function.